### PR TITLE
update pom.xml structs dependency

### DIFF
--- a/Cristaleria/pom.xml
+++ b/Cristaleria/pom.xml
@@ -29,7 +29,7 @@
   	<dependency>
   		<groupId>org.apache.struts</groupId>
   		<artifactId>struts2-core</artifactId>
-  		<version>2.2.3</version>
+  		<version>2.5.18</version>
   	</dependency>
   	<dependency>
   		<groupId>org.apache.struts</groupId>


### PR DESCRIPTION
Known high severity security vulnerability detected in org.apache.struts:struts2-core >= 2.0.1, <= 2.3.33 defined in pom.xml.
pom.xml update suggested: org.apache.struts:struts2-core ~> 2.3.34.